### PR TITLE
Fix ZIP creation on Windows by normalizing path separators

### DIFF
--- a/src/ZipGenerator.php
+++ b/src/ZipGenerator.php
@@ -44,6 +44,9 @@ class ZipGenerator
         );
 
         foreach ($files as $name => $file) {
+            // normalizamos el separador de rutas para Windows
+            $name = str_replace('\\', '/', $name);
+
             // excluimos archivos y carpetas ocultas
             if (substr($name, 0, 3) === './.') {
                 continue;
@@ -65,7 +68,7 @@ class ZipGenerator
             }
 
             // excluimos el propio zip
-            if ($name === $zipName) {
+            if ($name === './' . $zipName) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- Fix ZipGenerator to normalize path separators for Windows compatibility
- On Windows, RecursiveDirectoryIterator returns backslashes which broke the path comparison logic
- Added str_replace to normalize backslashes to forward slashes before processing
- Also fixed the zip file exclusion check to use './' prefix consistent with other checks